### PR TITLE
Resolve deprecation warning on package loop

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,8 @@
 
   - name: Install package dependencies
     package:
-      name: "{{ item }}"
+      name: "{{ netdata_deps }}"
       state: present
-    with_items: "{{ netdata_deps }}"
     when: netdata_present.stat.exists == False
     become: yes
 


### PR DESCRIPTION
Recent versions of ansible deprecate calling apt/yum in a loop and instead allow providing a package list directly. It currently results in this error:

```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `pkg: {{item}}`, please use `pkg: '{{netdata_deps}}'` and remove the loop. This
 feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

This patch makes this change.